### PR TITLE
Units AutoDeploy/DeployBlock on Ammo depletion

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -270,6 +270,7 @@ This page lists all the individual contributions to the project by their author.
   - Custom slaves free sound
   - Jumpjet crash rotation control
   - Vehicle voxel turret shadows & body multi-section shadows
+- **Fryone** - Auto-deploy/DeployBlock on ammo depletion
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -110,6 +110,7 @@
     <ClCompile Include="src\Ext\Unit\Hooks.DeployFire.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Unload.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -667,7 +667,7 @@ TurretShadow=   ; boolean
 ### IsSimpleDeployer vehicle auto-deploy / deploy block on depleted ammo
 
 - `OnAmmoDepletion_AutoDeploy` if set, converts/deploys vehicle when ammo is depleted. This feature requires ARES `Convert.Deploy` tag to work correctly.
-- `OnAmmoDepletion_DeployBlock` if set, disallows vehicle converting/deploying while ammo is depleted.
+- `OnAmmoDepletion_DeployUnlockAmount` determines amount of ammo, that allows vehicle converting/deploying command.
 
 In `rulesmd.ini`:
 ```ini
@@ -675,7 +675,7 @@ In `rulesmd.ini`:
 Ammo=2                                  ; Unit Ammo amount ,vanilla tag
 IsSimpleDeployer=yes                    ; Allowing to deploy ,vanilla tag
 Convert.Deploy=SOMEVEHICLEB             ; VehicleType to convert to ,Ares tag
-OnAmmoDepletion_DeployBlock=true        ; boolean
+OnAmmoDepletion_DeployUnlockAmount=2       ; int
 
 [SOMEVEHICLEB]                          ; VehicleType
 Ammo=2                                  ; Unit Ammo amount ,vanilla tag

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -664,6 +664,26 @@ In `artmd.ini`:
 TurretShadow=   ; boolean
 ```
 
+### IsSimpleDeployer vehicle auto-deploy / deploy block on depleted ammo
+
+- `OnAmmoDepletion_AutoDeploy` if set, converts/deploys vehicle when ammo is depleted. This feature requires ARES `Convert.Deploy` tag to work correctly.
+- `OnAmmoDepletion_DeployBlock` if set, disallows vehicle converting/deploying while ammo is depleted.
+
+In `rulesmd.ini`:
+```ini
+[SOMEVEHICLEA]                          ; VehicleType
+Ammo=2                                  ; Unit Ammo amount ,vanilla tag
+IsSimpleDeployer=yes                    ; Allowing to deploy ,vanilla tag
+Convert.Deploy=SOMEVEHICLEB             ; VehicleType to convert to ,Ares tag
+OnAmmoDepletion_DeployBlock=true        ; boolean
+
+[SOMEVEHICLEB]                          ; VehicleType
+Ammo=2                                  ; Unit Ammo amount ,vanilla tag
+IsSimpleDeployer=yes                    ; Allowing to deploy ,vanilla tag
+Convert.Deploy=SOMEVEHICLEA             ; VehicleType to convert to ,Ares tag
+OnAmmoDepletion_AutoDeploy=true         ; boolean
+```
+
 ## VoxelAnims
 
 ### Customizable debris & meteor impact and warhead detonation behaviour

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -314,6 +314,7 @@ New:
 - Unlimited skirmish colors (by Morton)
 - Example custom locomotor that circles around the target (by Kerbiter, CCHyper, with help from Otamaa; based on earlier experiment by CnCVK)
 - Vehicle voxel turret shadows & body multi-section shadows (by TwinkleStar)
+- Auto-deploy/DeployBlock on ammo depletion (by Fryone)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -65,6 +65,71 @@ void TechnoExt::ExtData::ApplyInterceptor()
 	}
 }
 
+//test
+void TechnoExt::ExtData::DepletedAmmoActions()
+{
+	auto const pTypeExt = this->TypeExtData;
+
+	if (!pTypeExt->AmmoDepAction_AutoDeploy && !pTypeExt->AmmoDepAction_DeployBlock)
+		return;
+
+	auto const pThis = this->OwnerObject();
+	auto const pType = pThis->GetTechnoType();
+
+	bool const isUnit = pThis->WhatAmI() == AbstractType::Unit;
+	// Initiate actions on depleted ammo
+	if (isUnit && pType->Ammo > 0)
+	{
+		auto const pUnit = abstract_cast<UnitClass*>(pThis);
+		bool pThisCanDeploySimple = pUnit->Type->IsSimpleDeployer;
+		if (pThis->Ammo <= 0)
+		{
+			if(pThisCanDeploySimple && pTypeExt->AmmoDepAction_AutoDeploy){
+				TechnoExt::DeployUnitSelf(pThis);
+				return;
+			}
+
+			if(pThisCanDeploySimple && pTypeExt->AmmoDepAction_DeployBlock){
+				TechnoExt::UnitDeployBlock(pThis);
+				return;
+			}
+		}
+	}
+	return;
+}
+
+void TechnoExt::DeployUnitSelf(TechnoClass* pThis)
+{
+	if (pThis->WhatAmI() == AbstractType::Unit)
+	{
+		//auto const pUnit = abstract_cast<UnitClass*>(pThis);
+		if (pThis->CanDeploySlashUnload())
+		{
+			//pUnit->SetTarget(nullptr);
+			pThis->QueueMission(Mission::Unload, true);
+			//continue attack
+		}
+	}
+	return;
+}
+
+
+void TechnoExt::UnitDeployBlock(TechnoClass* pThis)
+{
+	if (pThis->WhatAmI() == AbstractType::Unit)
+	{
+		auto const pUnit = abstract_cast<UnitClass*>(pThis);
+		if (pUnit->GetCurrentMission() == Mission::Unload)
+		{
+			pThis->QueueMission(Mission::Attack, true);
+			//pThis->Override_Mission(Mission::Unload, nullptr, nullptr); // I don't even know what this is
+			//pThis->QueueMission(pThis->GetTechnoType()->DefaultToGuardArea ? Mission::Area_Guard : Mission::Guard, true);
+			//pThis->NextMission();
+		}
+	}
+	return;
+}
+
 // TODO : Merge into new AttachEffects
 bool TechnoExt::ExtData::CheckDeathConditions()
 {

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -69,9 +69,7 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 {
 	auto const pThis = this->OwnerObject();
 	auto const pType = pThis->GetTechnoType();
-	bool const isUnit = pThis->WhatAmI() == AbstractType::Unit;
-
-	if (!isUnit && (pType->Ammo <= 0))
+	if ((pThis->WhatAmI() != AbstractType::Unit) || (pType->Ammo > 0))
 		return;
 
 	auto const pTypeExt = this->TypeExtData;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -99,17 +99,16 @@ void TechnoExt::UnitDeploySelf(TechnoClass* pThis)
 
 void TechnoExt::UnitDeployBlock(TechnoClass* pThis)
 {
-	if (pThis->WhatAmI() == AbstractType::Unit)
-	{
-		auto const pUnit = abstract_cast<UnitClass*>(pThis);
-		if (pUnit->GetCurrentMission() == Mission::Unload)
-		{
-			pThis->Override_Mission(Mission::Unload, nullptr, nullptr);
-			pThis->QueueMission(pThis->GetTechnoType()->DefaultToGuardArea ? Mission::Area_Guard : Mission::Guard, true);
-			pThis->NextMission();
-		}
-	}
-	return;
+	if (pThis->WhatAmI() != AbstractType::Unit)
+	    return;
+
+	auto const pUnit = abstract_cast<UnitClass*>(pThis);
+	if (pUnit->GetCurrentMission() != Mission::Unload)
+	    return;
+
+	pThis->Override_Mission(Mission::Unload, nullptr, nullptr);
+	pThis->QueueMission(pThis->GetTechnoType()->DefaultToGuardArea ? Mission::Area_Guard : Mission::Guard, true);
+	pThis->NextMission();
 }
 
 // TODO : Merge into new AttachEffects

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -81,7 +81,7 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 	    return;
 	if ((pThis->Ammo <= 0) && pTypeExt->OnAmmoDepletion_AutoDeploy)
 		TechnoExt::UnitDeploySelf(pThis);
-	else if ((pThis->Ammo <= 0) && pTypeExt->OnAmmoDepletion_DeployBlock)
+	else if (pTypeExt->OnAmmoDepletion_DeployUnlockAmount != 0 && pThis->Ammo < pTypeExt->OnAmmoDepletion_DeployUnlockAmount)
 		TechnoExt::UnitDeployBlock(pThis);
 	return;
 }

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -65,7 +65,6 @@ void TechnoExt::ExtData::ApplyInterceptor()
 	}
 }
 
-//test
 void TechnoExt::ExtData::DepletedAmmoActions()
 {
 	auto const pThis = this->OwnerObject();

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -69,7 +69,7 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 {
 	auto const pThis = this->OwnerObject();
 	auto const pType = pThis->GetTechnoType();
-	if ((pThis->WhatAmI() != AbstractType::Unit) || (pType->Ammo > 0))
+	if ((pThis->WhatAmI() != AbstractType::Unit) || (pType->Ammo <= 0))
 		return;
 
 	auto const pTypeExt = this->TypeExtData;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -80,12 +80,6 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 	    return;
 	if ((pThis->Ammo <= 0) && pTypeExt->OnAmmoDepletion_AutoDeploy)
 		pThis->QueueMission(Mission::Unload, true);
-	else if (pUnit->GetCurrentMission() == Mission::Unload
-			&& pTypeExt->OnAmmoDepletion_DeployUnlockAmount != 0
-			&& pThis->Ammo < pTypeExt->OnAmmoDepletion_DeployUnlockAmount)
-		{
-			pUnit->QueueMission(pThis->GetTechnoType()->DefaultToGuardArea ? Mission::Area_Guard : Mission::Guard, true);
-		}
 	return;
 }
 

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -99,14 +99,13 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 
 void TechnoExt::UnitDeploySelf(TechnoClass* pThis)
 {
-	if (pThis->WhatAmI() == AbstractType::Unit)
-	{
-		if (pThis->CanDeploySlashUnload())
-		{
-			pThis->QueueMission(Mission::Unload, true);
-		}
-	}
-	return;
+	if (pThis->WhatAmI() != AbstractType::Unit)
+	    return;
+
+	if (!pThis->CanDeploySlashUnload())
+        return;
+
+	pThis->QueueMission(Mission::Unload, true);
 }
 
 void TechnoExt::UnitDeployBlock(TechnoClass* pThis)

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -73,8 +73,6 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 		return;
 
 	auto const pTypeExt = this->TypeExtData;
-	if (!pTypeExt->AmmoDepAction_AutoDeploy && !pTypeExt->AmmoDepAction_DeployBlock)
-		return;
 
 	auto const pUnit = abstract_cast<UnitClass*>(pThis);
 	bool const pThisCanDeploy = pUnit->Type->IsSimpleDeployer;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -75,25 +75,14 @@ void TechnoExt::ExtData::DepletedAmmoActions()
 	auto const pTypeExt = this->TypeExtData;
 
 	auto const pUnit = abstract_cast<UnitClass*>(pThis);
-	bool const pThisCanDeploy = pUnit->Type->IsSimpleDeployer;
+	bool const ThisCanDeploy = pUnit->Type->IsSimpleDeployer;
 
-	if (pThisCanDeploy)
-	{
-		if (pThis->Ammo <= 0)
-		{
-			if(pTypeExt->AmmoDepAction_AutoDeploy)
-			{
-				TechnoExt::UnitDeploySelf(pThis);
-				return;
-			}
-
-			if(pTypeExt->AmmoDepAction_DeployBlock)
-			{
-				TechnoExt::UnitDeployBlock(pThis);
-				return;
-			}
-		}
-	}
+	if (!ThisCanDeploy)
+	    return;
+	if ((pThis->Ammo <= 0) && pTypeExt->OnAmmoDepletion_AutoDeploy)
+		TechnoExt::UnitDeploySelf(pThis);
+	else if ((pThis->Ammo <= 0) && pTypeExt->OnAmmoDepletion_DeployBlock)
+		TechnoExt::UnitDeployBlock(pThis);
 	return;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -69,7 +69,6 @@ public:
 		void UpdateLaserTrails();
 		void InitializeLaserTrails();
 		void UpdateMindControlAnim();
-		void UnitDeployCommand();
 
 		virtual ~ExtData() override;
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -108,8 +108,6 @@ public:
 
 	static void ChangeOwnerMissionFix(FootClass* pThis);
 	static void KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation);
-	static void UnitDeploySelf(TechnoClass* pThis);
-	static void UnitDeployBlock(TechnoClass* pThis);
 	static void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 	static void ApplyMindControlRangeLimit(TechnoClass* pThis);
 	static void ObjectKilledBy(TechnoClass* pThis, TechnoClass* pKiller);

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -60,6 +60,7 @@ public:
 
 		void ApplyInterceptor();
 		bool CheckDeathConditions();
+		void DepletedAmmoActions();
 		void EatPassengers();
 		void UpdateShield();
 		void UpdateOnTunnelEnter();
@@ -68,6 +69,7 @@ public:
 		void UpdateLaserTrails();
 		void InitializeLaserTrails();
 		void UpdateMindControlAnim();
+		void UnitDeployCommand();
 
 		virtual ~ExtData() override;
 
@@ -107,6 +109,8 @@ public:
 
 	static void ChangeOwnerMissionFix(FootClass* pThis);
 	static void KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation);
+	static void DeployUnitSelf(TechnoClass* pThis);
+	static void UnitDeployBlock(TechnoClass* pThis);
 	static void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 	static void ApplyMindControlRangeLimit(TechnoClass* pThis);
 	static void ObjectKilledBy(TechnoClass* pThis, TechnoClass* pKiller);

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -109,7 +109,7 @@ public:
 
 	static void ChangeOwnerMissionFix(FootClass* pThis);
 	static void KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation);
-	static void DeployUnitSelf(TechnoClass* pThis);
+	static void UnitDeploySelf(TechnoClass* pThis);
 	static void UnitDeployBlock(TechnoClass* pThis);
 	static void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 	static void ApplyMindControlRangeLimit(TechnoClass* pThis);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -29,6 +29,7 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	pExt->UpdateShield();
 	pExt->ApplySpawnLimitRange();
 	pExt->UpdateLaserTrails();
+	pExt->DepletedAmmoActions();
 
 	TechnoExt::ApplyMindControlRangeLimit(pThis);
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -153,8 +153,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->ShieldType.Read(exINI, pSection, "ShieldType", true);
 
-	this->AmmoDepAction_AutoDeploy.Read(exINI, pSection, "OnAmmoDepletion.AutoDeploy");
-	this->AmmoDepAction_DeployBlock.Read(exINI, pSection, "OnAmmoDepletion.DeployBlock");
+	this->OnAmmoDepletion_AutoDeploy.Read(exINI, pSection, "OnAmmoDepletion.AutoDeploy");
+	this->OnAmmoDepletion_DeployBlock.Read(exINI, pSection, "OnAmmoDepletion.DeployBlock");
 
 	this->AutoDeath_Behavior.Read(exINI, pSection, "AutoDeath.Behavior");
 	this->AutoDeath_VanishAnimation.Read(exINI, pSection, "AutoDeath.VanishAnimation");

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -406,8 +406,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ShieldType)
 		.Process(this->PassengerDeletionType)
 
-		.Process(this->AmmoDepAction_AutoDeploy)
-		.Process(this->AmmoDepAction_DeployBlock)
+		.Process(this->OnAmmoDepletion_AutoDeploy)
+		.Process(this->OnAmmoDepletion_DeployBlock)
 
 		.Process(this->AutoDeath_Behavior)
 		.Process(this->AutoDeath_VanishAnimation)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -153,8 +153,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->ShieldType.Read(exINI, pSection, "ShieldType", true);
 
-	this->OnAmmoDepletion_AutoDeploy.Read(exINI, pSection, "OnAmmoDepletion.AutoDeploy");
-	this->OnAmmoDepletion_DeployBlock.Read(exINI, pSection, "OnAmmoDepletion.DeployBlock");
+	this->OnAmmoDepletion_AutoDeploy.Read(exINI, pSection, "OnAmmoDepletion_AutoDeploy");
+	this->OnAmmoDepletion_DeployBlock.Read(exINI, pSection, "OnAmmoDepletion_DeployBlock");
 
 	this->AutoDeath_Behavior.Read(exINI, pSection, "AutoDeath.Behavior");
 	this->AutoDeath_VanishAnimation.Read(exINI, pSection, "AutoDeath.VanishAnimation");

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -154,7 +154,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ShieldType.Read(exINI, pSection, "ShieldType", true);
 
 	this->OnAmmoDepletion_AutoDeploy.Read(exINI, pSection, "OnAmmoDepletion_AutoDeploy");
-	this->OnAmmoDepletion_DeployBlock.Read(exINI, pSection, "OnAmmoDepletion_DeployBlock");
+	this->OnAmmoDepletion_DeployUnlockAmount.Read(exINI, pSection, "OnAmmoDepletion_DeployUnlockAmount");
 
 	this->AutoDeath_Behavior.Read(exINI, pSection, "AutoDeath.Behavior");
 	this->AutoDeath_VanishAnimation.Read(exINI, pSection, "AutoDeath.VanishAnimation");
@@ -407,7 +407,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PassengerDeletionType)
 
 		.Process(this->OnAmmoDepletion_AutoDeploy)
-		.Process(this->OnAmmoDepletion_DeployBlock)
+		.Process(this->OnAmmoDepletion_DeployUnlockAmount)
 
 		.Process(this->AutoDeath_Behavior)
 		.Process(this->AutoDeath_VanishAnimation)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -153,6 +153,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->ShieldType.Read(exINI, pSection, "ShieldType", true);
 
+	this->AmmoDepAction_AutoDeploy.Read(exINI, pSection, "OnAmmoDepletion.AutoDeploy");
+	this->AmmoDepAction_DeployBlock.Read(exINI, pSection, "OnAmmoDepletion.DeployBlock");
+
 	this->AutoDeath_Behavior.Read(exINI, pSection, "AutoDeath.Behavior");
 	this->AutoDeath_VanishAnimation.Read(exINI, pSection, "AutoDeath.VanishAnimation");
 	this->AutoDeath_OnAmmoDepletion.Read(exINI, pSection, "AutoDeath.OnAmmoDepletion");
@@ -402,6 +405,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->InitialStrength)
 		.Process(this->ShieldType)
 		.Process(this->PassengerDeletionType)
+
+		.Process(this->AmmoDepAction_AutoDeploy)
+		.Process(this->AmmoDepAction_DeployBlock)
 
 		.Process(this->AutoDeath_Behavior)
 		.Process(this->AutoDeath_VanishAnimation)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -49,7 +49,7 @@ public:
 		std::unique_ptr<PassengerDeletionTypeClass> PassengerDeletionType;
 
 		Valueable<bool> OnAmmoDepletion_AutoDeploy;
-		Valueable<bool> OnAmmoDepletion_DeployBlock;
+		Valueable<int> OnAmmoDepletion_DeployUnlockAmount;
 
 		Nullable<AutoDeathBehavior> AutoDeath_Behavior;
 		Nullable<AnimTypeClass*> AutoDeath_VanishAnimation;
@@ -244,7 +244,7 @@ public:
 			, DeployingAnim_UseUnitDrawer { true }
 
 			, OnAmmoDepletion_AutoDeploy { false }
-			, OnAmmoDepletion_DeployBlock { false }
+			, OnAmmoDepletion_DeployUnlockAmount { 0 }
 
 			, AutoDeath_Behavior { }
 			, AutoDeath_VanishAnimation {}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -43,7 +43,6 @@ public:
 		Valueable<bool> MultiMindControl_ReleaseVictim;
 		Valueable<int> CameoPriority;
 		Valueable<bool> NoManualMove;
-		Valueable<bool> AutoDeployOnDepletedAmmo;//testing
 		Nullable<int> InitialStrength;
 
 		Valueable<ShieldTypeClass*> ShieldType;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -243,8 +243,8 @@ public:
 			, DeployingAnim_ReverseForUndeploy { true }
 			, DeployingAnim_UseUnitDrawer { true }
 
-			, AmmoDepAction_AutoDeploy { false }
-			, AmmoDepAction_DeployBlock { false }
+			, OnAmmoDepletion_AutoDeploy { false }
+			, OnAmmoDepletion_DeployBlock { false }
 
 			, AutoDeath_Behavior { }
 			, AutoDeath_VanishAnimation {}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -49,8 +49,8 @@ public:
 		Valueable<ShieldTypeClass*> ShieldType;
 		std::unique_ptr<PassengerDeletionTypeClass> PassengerDeletionType;
 
-		Valueable<bool> AmmoDepAction_AutoDeploy;
-		Valueable<bool> AmmoDepAction_DeployBlock;
+		Valueable<bool> OnAmmoDepletion_AutoDeploy;
+		Valueable<bool> OnAmmoDepletion_DeployBlock;
 
 		Nullable<AutoDeathBehavior> AutoDeath_Behavior;
 		Nullable<AnimTypeClass*> AutoDeath_VanishAnimation;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -43,10 +43,14 @@ public:
 		Valueable<bool> MultiMindControl_ReleaseVictim;
 		Valueable<int> CameoPriority;
 		Valueable<bool> NoManualMove;
+		Valueable<bool> AutoDeployOnDepletedAmmo;//testing
 		Nullable<int> InitialStrength;
 
 		Valueable<ShieldTypeClass*> ShieldType;
 		std::unique_ptr<PassengerDeletionTypeClass> PassengerDeletionType;
+
+		Valueable<bool> AmmoDepAction_AutoDeploy;
+		Valueable<bool> AmmoDepAction_DeployBlock;
 
 		Nullable<AutoDeathBehavior> AutoDeath_Behavior;
 		Nullable<AnimTypeClass*> AutoDeath_VanishAnimation;
@@ -239,6 +243,9 @@ public:
 			, DeployingAnim_KeepUnitVisible { false }
 			, DeployingAnim_ReverseForUndeploy { true }
 			, DeployingAnim_UseUnitDrawer { true }
+
+			, AmmoDepAction_AutoDeploy { false }
+			, AmmoDepAction_DeployBlock { false }
 
 			, AutoDeath_Behavior { }
 			, AutoDeath_VanishAnimation {}

--- a/src/Ext/Unit/Hooks.Unload.cpp
+++ b/src/Ext/Unit/Hooks.Unload.cpp
@@ -1,0 +1,38 @@
+#include <UnitClass.h>
+
+//#include <Ext/Techno/Body.h>
+#include <Ext/TechnoType/Body.h>
+#include <Utilities/EnumFunctions.h>
+#include <Utilities/GeneralUtils.h>
+#include <Utilities/Macro.h>
+
+DEFINE_HOOK(0x739AC6, UnitClass_ToggleDeployState_IgnoreDeploying, 0x6)
+{
+	enum {Continue = 0x739ACC, Ignore = 0x739CBF};
+
+	GET(UnitClass* const, pThis, ECX);
+
+	R->EAX(pThis->GetTechnoType());
+	auto const pThisTechno = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+	if(pThisTechno->OnAmmoDepletion_DeployUnlockAmount != 0 && pThis->Ammo < pThisTechno->OnAmmoDepletion_DeployUnlockAmount)
+	{
+		return Ignore;
+	}
+	return Continue;
+}
+
+//blockForDeployed
+DEFINE_HOOK(0x739CD7, UnitClass_ToggleSimpleDeploy_IgnoreDeploying, 0x6)
+{
+	enum {Continue = 0x739CDD, Ignore = 0x739EB8};
+
+	GET(UnitClass* const, pThis, ECX);
+
+	R->AL(pThis->Deployed);
+	auto const pThisTechno = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+	if(pThisTechno->OnAmmoDepletion_DeployUnlockAmount != 0 && pThis->Ammo < pThisTechno->OnAmmoDepletion_DeployUnlockAmount)
+	{
+		return Ignore;
+	}
+	return Continue;
+}


### PR DESCRIPTION
Requires units to have:
'Ammo' > 0;
'IsSimpleDeployer=yes';
'Convert.Deploy='.

Parameters
'OnAmmoDepletion_AutoDeploy=true' - uses Deploy command on unit when Ammo gets 0.
'OnAmmoDepletion_DeployUnlockAmount=a' - all Deploy commands on unit will turn into AreaGuard/Guard if Ammo not equals a.